### PR TITLE
feat: simplify Home by using user context in Chat

### DIFF
--- a/app/c/[chatId]/page.tsx
+++ b/app/c/[chatId]/page.tsx
@@ -51,7 +51,6 @@ export default async function PrivatePage({
     <LayoutApp>
       <Chat
         initialMessages={formattedMessages}
-        userId={userData.user.id}
         chatId={chatId}
         preferredModel={chatData.model || ""}
         systemPrompt={chatData.system_prompt || "You are a helpful assistant."}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,10 @@
-import { MODEL_DEFAULT } from "@/lib/config"
-import { createClient } from "@/lib/supabase/server"
 import Chat from "./components/chat/chat"
 import LayoutApp from "./components/layout/layout-app"
 
 export default async function Home() {
-  const supabase = await createClient()
-  const { data: auth } = await supabase.auth.getUser()
-
-  const { data: user } = await supabase
-    .from("users")
-    .select("preferred_model")
-    .eq("id", auth?.user?.id || "")
-    .single()
-
   return (
     <LayoutApp>
-      <Chat
-        userId={auth?.user?.id}
-        preferredModel={user?.preferred_model || MODEL_DEFAULT}
-      />
+      <Chat />
     </LayoutApp>
   )
 }


### PR DESCRIPTION
- Removed getUser() and preferred_model fetch from the Home route
- Chat now uses useUser() to access user ID and preferred model
- Reduces SSR work and improves initial load performance







