### PR TITLE
refactor: client-side caching with IndexedDB

### DIFF
--- a/lib/chat-store/chats/provider.tsx
+++ b/lib/chat-store/chats/provider.tsx
@@ -3,7 +3,6 @@
 import { toast } from "@/components/ui/toast"
 import { createContext, useContext, useEffect, useState } from "react"
 import { MODEL_DEFAULT, SYSTEM_PROMPT_DEFAULT } from "../../config"
-import { clearAllIndexedDBStores } from "../persist"
 import type { Chats } from "../types"
 import {
   createNewChat as createNewChatFromDb,

--- a/lib/chat-store/messages/provider.tsx
+++ b/lib/chat-store/messages/provider.tsx
@@ -3,7 +3,7 @@
 import { toast } from "@/components/ui/toast"
 import type { Message as MessageAISDK } from "ai"
 import { createContext, useContext, useEffect, useState } from "react"
-import { clearAllIndexedDBStores, writeToIndexedDB } from "../persist"
+import { writeToIndexedDB } from "../persist"
 import {
   addMessage,
   cacheMessages,


### PR DESCRIPTION
Set up safe and simple IndexedDB persistence for chats and messages.

- Added versioned init with fallback
- Auto-creates stores (chats, messages, sync)
- Ensures writes/reads only run client-side
- Used for local caching and offline support

