### PR TITLE
feat(config): add support for Gemini models and SDK integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,8 @@ OPENAI_API_KEY=your_openai_api_key
 # Mistral
 MISTRAL_API_KEY=your_mistral_api_key
 
+# Google
+GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key
+
 # CSRF
 CSRF_SECRET=your_csrf_secret

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,6 +4,7 @@ import Gemini from "@/components/icons/gemini"
 import Grok from "@/components/icons/grok"
 import Mistral from "@/components/icons/mistral"
 import OpenAI from "@/components/icons/openai"
+import { google } from "@ai-sdk/google"
 import { mistral } from "@ai-sdk/mistral"
 import { openai } from "@ai-sdk/openai"
 import {
@@ -55,19 +56,6 @@ export const MODELS_NOT_AVAILABLE = [
     ],
   },
   {
-    id: "gemini-1.5-pro",
-    name: "Gemini 1.5 Pro",
-    provider: "gemini",
-    available: false,
-    api_sdk: false,
-    features: [
-      {
-        id: "file-upload",
-        enabled: true,
-      },
-    ],
-  },
-  {
     id: "claude-3-5-sonnet",
     name: "Claude 3.5 Sonnet",
     provider: "claude",
@@ -97,32 +85,6 @@ export const MODELS_NOT_AVAILABLE = [
     id: "grok-2",
     name: "Grok 2",
     provider: "grok",
-    available: false,
-    api_sdk: false,
-    features: [
-      {
-        id: "file-upload",
-        enabled: true,
-      },
-    ],
-  },
-  {
-    id: "gemini-2.0-flash",
-    name: "Gemini 2.0 Flash",
-    provider: "gemini",
-    available: false,
-    api_sdk: false,
-    features: [
-      {
-        id: "file-upload",
-        enabled: true,
-      },
-    ],
-  },
-  {
-    id: "gemini-2.5-pro",
-    name: "Gemini 2.5 Pro",
-    provider: "gemini",
     available: false,
     api_sdk: false,
     features: [
@@ -208,6 +170,81 @@ export const MODELS = [
     description:
       "Fine-tuned for chat. A lighter, faster option for everyday use.",
   },
+  {
+    id: "gemini-2.5-pro-preview",
+    name: "Gemini 2.5 Pro Preview",
+    provider: "gemini",
+    available: true,
+    api_sdk: google("models/gemini-2.5-pro-preview-03-25"),
+    features: [
+      {
+        id: "file-upload",
+        enabled: true,
+      },
+    ],
+    icon: Gemini,
+    description: "Google's stable production model, optimized for reliability.",
+  },
+  {
+    id: "gemini-2.5-pro-exp",
+    name: "Gemini 2.5 Pro Experimental",
+    provider: "gemini",
+    available: true,
+    api_sdk: google("models/gemini-2.5-pro-exp-03-25"),
+    features: [
+      {
+        id: "file-upload",
+        enabled: true,
+      },
+    ],
+    icon: Gemini,
+    description: "Google's experimental model.",
+  },
+  {
+    id: "gemini-2.5-flash",
+    name: "Gemini 2.5 Flash",
+    provider: "gemini",
+    available: true,
+    api_sdk: google("models/gemini-2.5-flash-preview-04-17"),
+    features: [
+      {
+        id: "file-upload",
+        enabled: true,
+      },
+    ],
+    icon: Gemini,
+    description: "Google's latest flash model.",
+  },
+  {
+    id: "gemini-2.0-flash",
+    name: "Gemini 2.0 Flash",
+    provider: "gemini",
+    available: true,
+    api_sdk: google("models/gemini-2.0-flash"),
+    features: [
+      {
+        id: "file-upload",
+        enabled: true,
+      },
+    ],
+    icon: Gemini,
+    description: "A fast and efficient Gemini model.",
+  },
+  {
+    id: "gemini-2.0-flash-lite",
+    name: "Gemini 2.0 Flash Lite",
+    provider: "gemini",
+    available: true,
+    api_sdk: google("models/gemini-2.0-flash-lite"),
+    features: [
+      {
+        id: "file-upload",
+        enabled: true,
+      },
+    ],
+    icon: Gemini,
+    description: "A lightweight version of the Gemini Flash model.",
+  },
 ] as Model[]
 
 export const MODELS_OPTIONS = [
@@ -233,12 +270,6 @@ const PROVIDERS_NOT_AVAILABLE = [
     icon: DeepSeek,
   },
   {
-    id: "gemini",
-    name: "Gemini",
-    icon: Gemini,
-    available: false,
-  },
-  {
     id: "claude",
     name: "Claude",
     available: false,
@@ -262,6 +293,11 @@ export const PROVIDERS = [
     id: "mistral",
     name: "Mistral",
     icon: Mistral,
+  },
+  {
+    id: "gemini",
+    name: "Gemini",
+    icon: Gemini,
   },
 ] as Provider[]
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@ai-sdk/google": "^1.2.11",
     "@ai-sdk/mistral": "^1.2.0",
     "@ai-sdk/openai": "^1.3.12",
+    "@ai-sdk/react": "^1.2.9",
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",


### PR DESCRIPTION
This commit introduces support for multiple Gemini models, including Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.0 Flash, and Gemini 2.0 Flash Lite. It also integrates the Google SDK for these models, enabling their availability and functionality within the application. Additionally, the Gemini provider is now marked as available in the providers list.