### PR TITLE
Adding Supabase anonymous signin for guest users

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,6 +108,14 @@ Here are the detailed steps to set up Google OAuth:
 10. Paste the Client ID and Client Secret in the Google provider settings
 11. Save the changes
 
+#### Guest user setup
+
+1. Go to your Supabase project dashboard
+2. Navigate to Authentication > Providers
+3. Toggle on "Allow anonymous sign-ins"
+
+This allows users limited access to try the product before properly creating an account.
+
 ### Database Schema
 
 Create the following tables in your Supabase SQL editor:


### PR DESCRIPTION
I may be doing something wrong, but when I ran Zola locally, guest users were not working. I would get the following error when attempting to send a message in a non-authenticated state:

```
Error creating guest user: {
  code: '23503',
  details: 'Key (id)=([UUID-UUID-UUID-UUID]) is not present in table "users".',
  hint: null,
  message: 'insert or update on table "users" violates foreign key constraint "users_id_fkey"'
}
```

I'm not sure how this is working on zola.chat, or (again), if I'm doing something wrong. But regardless this is how I got it working:

1. Turn on anonymous auth on Supabase (added to `INSTALL.md`)
2. When creating a guest user, use `supabase.auth.signInAnonymously()` to add an entry to the auth table first before creating a public.users entry