### PR TITLE
Remove user_id from messages insertion

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -53,7 +53,6 @@ export async function POST(req: Request) {
         content: sanitizeUserInput(userMessage.content),
         experimental_attachments:
           userMessage.experimental_attachments as unknown as Attachment[],
-        user_id: userId,
       })
       if (msgError) {
         console.error("Error saving user message:", msgError)


### PR DESCRIPTION
The DB schema in README doesn't include user_id field, so user message insertions were failing with:

```
Error saving user message: {
  code: 'PGRST204',
  details: null,
  hint: null,
  message: "Could not find the 'user_id' column of 'messages' in the schema cache"
}
```

So either this change should be made, or the DB schema should be updated to have the user_id column (and updated in README)