### PR TITLE
fix: Enable model selector drawer to open on mobile

### DIFF
--- a/components/common/model-selector/base.tsx
+++ b/components/common/model-selector/base.tsx
@@ -167,10 +167,7 @@ export function ModelSelector({
         />
         <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
           <DrawerTrigger asChild>
-            <Tooltip>
-              <TooltipTrigger asChild>{trigger}</TooltipTrigger>
-              <TooltipContent>Switch model (⌘⇧M)</TooltipContent>
-            </Tooltip>
+            {trigger}
           </DrawerTrigger>
           <DrawerContent>
             <DrawerHeader>


### PR DESCRIPTION
# **Fix: Enable model selector drawer to open on mobile**

## **Overview**

On mobile devices, tapping the model selector button did not open the model selection drawer. This prevented users from switching models on mobile, impacting usability and feature accessibility.

## **Implementation Details**

- Refactored the mobile rendering of the ModelSelector component to ensure the DrawerTrigger directly wraps the trigger button.

- Removed the Tooltip wrapper from around the DrawerTrigger on mobile, as it was interfering with click/tap events.

- No changes were made to the desktop experience; only the mobile interaction was affected.
