### PR TITLE
fix: rollback codeblock top and links in mardkwon

### DIFF
--- a/components/prompt-kit/markdown.tsx
+++ b/components/prompt-kit/markdown.tsx
@@ -1,10 +1,16 @@
+import { LinkMarkdown } from "@/app/components/chat/link-markdown"
 import { cn } from "@/lib/utils"
 import { marked } from "marked"
 import { memo, useId, useMemo } from "react"
 import ReactMarkdown, { Components } from "react-markdown"
 import remarkBreaks from "remark-breaks"
 import remarkGfm from "remark-gfm"
-import { CodeBlock, CodeBlockCode } from "../prompt-kit/code-block"
+import { ButtonCopy } from "../common/button-copy"
+import {
+  CodeBlock,
+  CodeBlockCode,
+  CodeBlockGroup,
+} from "../prompt-kit/code-block"
 
 export type MarkdownProps = {
   children: string
@@ -48,8 +54,27 @@ const INITIAL_COMPONENTS: Partial<Components> = {
 
     return (
       <CodeBlock className={className}>
+        <CodeBlockGroup className="flex h-9 items-center justify-between px-4">
+          <div className="text-muted-foreground py-1 pr-2 font-mono text-xs">
+            {language}
+          </div>
+        </CodeBlockGroup>
+        <div className="sticky top-16 lg:top-0">
+          <div className="absolute right-0 bottom-0 flex h-9 items-center pr-1.5">
+            <ButtonCopy code={children as string} />
+          </div>
+        </div>
         <CodeBlockCode code={children as string} language={language} />
       </CodeBlock>
+    )
+  },
+  a: function AComponent({ href, children, ...props }) {
+    if (!href) return <span {...props}>{children}</span>
+
+    return (
+      <LinkMarkdown href={href} {...props}>
+        {children}
+      </LinkMarkdown>
     )
   },
   pre: function PreComponent({ children }) {


### PR DESCRIPTION
-rollback codeblock top 
-rollback links UI in mardkwon