### PR TITLE
fix: block message submission on empty or whitespace-only input

### DIFF
--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -63,9 +63,9 @@ export function ChatInput({
     defaultAgent: currentAgent,
   })
 
-  const isEmpty = (value: string) => !/[^\s]/.test(value)
   const selectModelConfig = MODELS.find((model) => model.id === selectedModel)
   const noToolSupport = selectModelConfig?.tools
+  const isOnlyWhitespace = (text: string) => !/[^\s]/.test(text)
 
   const handleSend = useCallback(() => {
     if (isSubmitting) {
@@ -96,10 +96,11 @@ export function ChatInput({
       }
 
       if (e.key === "Enter" && !e.shiftKey && !agentCommand.showAgentCommand) {
-        e.preventDefault()
-        if (isEmpty(value)) {
+        if (isOnlyWhitespace(value)) {
           return
         }
+
+        e.preventDefault()
         onSend()
       }
     },
@@ -225,7 +226,7 @@ export function ChatInput({
               <Button
                 size="sm"
                 className="size-9 rounded-full transition-all duration-300 ease-out"
-                disabled={!value || isSubmitting || isEmpty(value)}
+                disabled={!value || isSubmitting || isOnlyWhitespace(value)}
                 type="button"
                 onClick={handleSend}
                 aria-label={status === "streaming" ? "Stop" : "Send message"}

--- a/app/components/chat-input/chat-input.tsx
+++ b/app/components/chat-input/chat-input.tsx
@@ -63,6 +63,7 @@ export function ChatInput({
     defaultAgent: currentAgent,
   })
 
+  const isEmpty = (value: string) => !/[^\s]/.test(value)
   const selectModelConfig = MODELS.find((model) => model.id === selectedModel)
   const noToolSupport = selectModelConfig?.tools
 
@@ -96,10 +97,13 @@ export function ChatInput({
 
       if (e.key === "Enter" && !e.shiftKey && !agentCommand.showAgentCommand) {
         e.preventDefault()
+        if (isEmpty(value)) {
+          return
+        }
         onSend()
       }
     },
-    [agentCommand, isSubmitting, onSend, status]
+    [agentCommand, isSubmitting, onSend, status, value]
   )
 
   const handlePaste = useCallback(
@@ -221,7 +225,7 @@ export function ChatInput({
               <Button
                 size="sm"
                 className="size-9 rounded-full transition-all duration-300 ease-out"
-                disabled={!value || isSubmitting}
+                disabled={!value || isSubmitting || isEmpty(value)}
                 type="button"
                 onClick={handleSend}
                 aria-label={status === "streaming" ? "Stop" : "Send message"}


### PR DESCRIPTION
### Description
Previously, pressing the Enter key repeatedly would trigger new chat submissions even when the input contained only whitespace characters. This led to the creation of multiple empty chat messages.

This PR fixes that by adding a check for non-whitespace input when the Enter key is pressed. If the input is empty or contains only spaces, the submission is prevented.

### Changes
- Added a `isOnlyWhitespace` utility to check if the input contains meaningful characters
- Prevented form submission when input is empty or whitespace-only