### PR TITLE
feat: sort chats by last message usage (via updated_at)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,6 +209,7 @@ CREATE TABLE chats (
   system_prompt TEXT,
   agent_id UUID,
   created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at: TIMESTAMPTZ DEFAULT NOW(),
   public BOOLEAN DEFAULT FALSE NOT NULL, -- Added NOT NULL based on TS type
   CONSTRAINT chats_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
   CONSTRAINT chats_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE SET NULL -- Assuming SET NULL, adjust if needed

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -56,6 +56,7 @@ export function Chat() {
     createNewChat,
     getChatById,
     updateChatModel,
+    bumpChat,
     isLoading: isChatsLoading,
   } = useChats()
 
@@ -197,6 +198,9 @@ export function Chat() {
         cleanupOptimisticAttachments(optimisticMessage.experimental_attachments)
         return
       }
+
+      // refresh the chat history (in sidebar+command/drawer)
+      bumpChat(currentChatId)
 
       if (input.length > MESSAGE_MAX_LENGTH) {
         toast({

--- a/app/components/chat/use-chat-utils.ts
+++ b/app/components/chat/use-chat-utils.ts
@@ -1,8 +1,8 @@
 import { toast } from "@/components/ui/toast"
 import { checkRateLimits } from "@/lib/api"
+import type { Chats } from "@/lib/chat-store/types"
 import { REMAINING_QUERY_ALERT_THRESHOLD } from "@/lib/config"
 import { Message } from "@ai-sdk/react"
-import type { Chats } from "@/lib/chat-store/types"
 
 type UseChatUtilsProps = {
   isAuthenticated: boolean

--- a/app/components/history/utils.ts
+++ b/app/components/history/utils.ts
@@ -29,12 +29,12 @@ export function groupChatsByDate(
   const olderChats: Record<number, Chats[]> = {}
 
   chats.forEach((chat) => {
-    if (!chat.created_at) {
+    if (!chat.updated_at) {
       todayChats.push(chat)
       return
     }
 
-    const chatTimestamp = new Date(chat.created_at).getTime()
+    const chatTimestamp = new Date(chat.updated_at).getTime()
 
     if (chatTimestamp >= today) {
       todayChats.push(chat)
@@ -45,7 +45,7 @@ export function groupChatsByDate(
     } else if (chatTimestamp >= yearStart) {
       thisYearChats.push(chat)
     } else {
-      const year = new Date(chat.created_at).getFullYear()
+      const year = new Date(chat.updated_at).getFullYear()
       if (!olderChats[year]) {
         olderChats[year] = []
       }

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -146,6 +146,7 @@ export type Database = {
         Row: {
           agent_id: string | null
           created_at: string | null
+          updated_at: string | null
           id: string
           model: string | null
           title: string | null
@@ -155,6 +156,7 @@ export type Database = {
         Insert: {
           agent_id?: string | null
           created_at?: string | null
+          updated_at?: string | null
           id?: string
           model?: string | null
           title?: string | null
@@ -164,6 +166,7 @@ export type Database = {
         Update: {
           agent_id?: string | null
           created_at?: string | null
+          updated_at?: string | null
           id?: string
           model?: string | null
           title?: string | null

--- a/lib/chat-store/chats/provider.tsx
+++ b/lib/chat-store/chats/provider.tsx
@@ -136,6 +136,7 @@ export function ChatsProvider({
       agent_id: agentId || null,
       user_id: userId,
       public: true,
+      updated_at: new Date().toISOString(),
     }
     setChats((prev) => [...prev, optimisticChat])
 

--- a/lib/chat-store/chats/provider.tsx
+++ b/lib/chat-store/chats/provider.tsx
@@ -89,7 +89,13 @@ export function ChatsProvider({
 
   const updateTitle = async (id: string, title: string) => {
     const prev = [...chats]
-    setChats((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)))
+    const updatedChatWithNewTitle = prev.map((c) =>
+      c.id === id ? { ...c, title, updated_at: new Date().toISOString() } : c
+    )
+    const sorted = updatedChatWithNewTitle.sort(
+      (a, b) => +new Date(b.updated_at || "") - +new Date(a.updated_at || "")
+    )
+    setChats(sorted)
     try {
       await updateChatTitle(id, title)
     } catch {

--- a/lib/chat-store/chats/provider.tsx
+++ b/lib/chat-store/chats/provider.tsx
@@ -42,6 +42,7 @@ interface ChatsContextType {
     agentId: string | null,
     isAuthenticated: boolean
   ) => Promise<void>
+  bumpChat: (id: string) => Promise<void>
 }
 const ChatsContext = createContext<ChatsContextType | null>(null)
 
@@ -198,6 +199,17 @@ export function ChatsProvider({
     await updateChatAgentFromDb(userId, chatId, agentId, isAuthenticated)
   }
 
+  const bumpChat = async (id: string) => {
+    const prev = [...chats]
+    const updatedChatWithNewUpdatedAt = prev.map((c) =>
+      c.id === id ? { ...c, updated_at: new Date().toISOString() } : c
+    )
+    const sorted = updatedChatWithNewUpdatedAt.sort(
+      (a, b) => +new Date(b.updated_at || "") - +new Date(a.updated_at || "")
+    )
+    setChats(sorted)
+  }
+
   return (
     <ChatsContext.Provider
       value={{
@@ -211,6 +223,7 @@ export function ChatsProvider({
         getChatById,
         updateChatModel,
         updateChatAgent,
+        bumpChat,
         isLoading,
       }}
     >


### PR DESCRIPTION
keep chats sorted by recent activity and improve UX with immediate visual updates

- added updated_at field to chats table
- created a Supabase trigger to auto-update chats.updated_at when a new message is inserted
- optimistically reorder chats client-side using bumpChat(chatId)
- integrated bumpChat into the message submit flow for instant UI feedback (no refetch needed)

