### PR TITLE
fix: correct theme variable usage in CodeBlockCode component

### DIFF
--- a/components/prompt-kit/code-block.tsx
+++ b/components/prompt-kit/code-block.tsx
@@ -39,7 +39,7 @@ function CodeBlockCode({
   className,
   ...props
 }: CodeBlockCodeProps) {
-  const { theme: appTheme } = useTheme()
+  const { resolvedTheme: appTheme } = useTheme()
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
 
   useEffect(() => {


### PR DESCRIPTION
Use `resolvedTheme` instead of `theme` to avoid theme mismatch when the theme is set to `system`

Before
![image](https://github.com/user-attachments/assets/623af1e6-e213-453f-ba3d-966b5645beb6)

After
![image](https://github.com/user-attachments/assets/f35ff149-e200-4983-8b47-f9b2880bc8ae)
