### PR TITLE
fix(ui): Resolve settings modal interaction issues in dropdown menu

### DIFF
--- a/app/components/layout/settings/settings-content.tsx
+++ b/app/components/layout/settings/settings-content.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
+import { DrawerClose } from "@/components/ui/drawer"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { isSupabaseEnabled } from "@/lib/supabase/config"
 import { cn, isDev } from "@/lib/utils"
@@ -25,14 +26,12 @@ import { UserProfile } from "./general/user-profile"
 import { ModelsSettings } from "./models/models-settings"
 
 type SettingsContentProps = {
-  onClose: () => void
   isDrawer?: boolean
 }
 
 type TabType = "general" | "appearance" | "models" | "connections"
 
 export function SettingsContent({
-  onClose,
   isDrawer = false,
 }: SettingsContentProps) {
   const [activeTab, setActiveTab] = useState<TabType>("general")
@@ -47,9 +46,11 @@ export function SettingsContent({
       {isDrawer && (
         <div className="border-border mb-2 flex items-center justify-between border-b px-4 pb-2">
           <h2 className="text-lg font-medium">Settings</h2>
-          <Button variant="ghost" size="icon" onClick={onClose}>
-            <XIcon className="size-4" />
-          </Button>
+          <DrawerClose asChild>
+            <Button variant="ghost" size="icon">
+              <XIcon className="size-4" />
+            </Button>
+          </DrawerClose>
         </div>
       )}
 

--- a/app/components/layout/settings/settings-trigger.tsx
+++ b/app/components/layout/settings/settings-trigger.tsx
@@ -15,9 +15,18 @@ import type React from "react"
 import { useState } from "react"
 import { SettingsContent } from "./settings-content"
 
-export function SettingsTrigger() {
+type SettingsTriggerProps = {
+  onOpenChange: (open: boolean) => void
+}
+
+export function SettingsTrigger({ onOpenChange }: SettingsTriggerProps) {
   const [open, setOpen] = useState(false)
   const isMobile = useBreakpoint(768)
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen)
+    onOpenChange(isOpen)
+  }
 
   const trigger = (
     <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
@@ -28,23 +37,23 @@ export function SettingsTrigger() {
 
   if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={setOpen}>
+      <Drawer open={open} onOpenChange={handleOpenChange}>
         <DrawerTrigger asChild>{trigger}</DrawerTrigger>
         <DrawerContent>
-          <SettingsContent isDrawer onClose={() => setOpen(false)} />
+          <SettingsContent isDrawer />
         </DrawerContent>
       </Drawer>
     )
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent className="flex h-[80%] min-h-[480px] w-full flex-col gap-0 p-0 sm:max-w-[768px]">
         <DialogHeader className="border-border border-b px-6 py-5">
           <DialogTitle>Settings</DialogTitle>
         </DialogHeader>
-        <SettingsContent onClose={() => setOpen(false)} />
+        <SettingsContent />
       </DialogContent>
     </Dialog>
   )

--- a/app/components/layout/user-menu.tsx
+++ b/app/components/layout/user-menu.tsx
@@ -16,18 +16,28 @@ import {
 } from "@/components/ui/tooltip"
 import { useUser } from "@/lib/user-store/provider"
 import { GithubLogoIcon } from "@phosphor-icons/react"
+import { useState } from "react"
 import { AppInfoTrigger } from "./app-info/app-info-trigger"
 import { FeedbackTrigger } from "./feedback/feedback-trigger"
 import { SettingsTrigger } from "./settings/settings-trigger"
 
 export function UserMenu() {
   const { user } = useUser()
+  const [isMenuOpen, setMenuOpen] = useState(false)
+  const [isSettingsOpen, setSettingsOpen] = useState(false)
 
   if (!user) return null
 
+  const handleSettingsOpenChange = (isOpen: boolean) => {
+    setSettingsOpen(isOpen)
+    if (!isOpen) {
+      setMenuOpen(false)
+    }
+  }
+
   return (
     // fix shadcn/ui / radix bug when dialog into dropdown menu
-    <DropdownMenu modal={false}>
+    <DropdownMenu open={isMenuOpen} onOpenChange={setMenuOpen} modal={false}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger>
@@ -44,6 +54,13 @@ export function UserMenu() {
         align="end"
         forceMount
         onCloseAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={(e) => {
+          if (isSettingsOpen) {
+            e.preventDefault()
+            return
+          }
+          setMenuOpen(false)
+        }}
       >
         <DropdownMenuItem className="flex flex-col items-start gap-0 no-underline hover:bg-transparent focus:bg-transparent">
           <span>{user?.display_name}</span>
@@ -52,7 +69,7 @@ export function UserMenu() {
           </span>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <SettingsTrigger />
+        <SettingsTrigger onOpenChange={handleSettingsOpenChange} />
         <FeedbackTrigger />
         <AppInfoTrigger />
         <DropdownMenuSeparator />


### PR DESCRIPTION
This pull request addresses a series of interaction bugs related to the settings modal when opened from the user dropdown menu. The initial problem was specific to Firefox (#228), where the modal would close immediately after opening. Subsequent fixes introduced other issues, such as the dropdown closing prematurely or not closing along with the modal.

Fixes #228 