### PR TITLE
feat: add preferences user schema

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -250,6 +250,33 @@ CREATE TABLE user_keys (
   PRIMARY KEY (user_id, provider)
 );
 
+-- User preferences table
+CREATE TABLE user_preferences (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  layout TEXT DEFAULT 'fullscreen',
+  prompt_suggestions BOOLEAN DEFAULT true,
+  show_tool_invocations BOOLEAN DEFAULT true,
+  show_conversation_previews BOOLEAN DEFAULT true,
+  multi_model_enabled BOOLEAN DEFAULT false,
+  hidden_models TEXT[] DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Optional: keep updated_at in sync for user_preferences
+CREATE OR REPLACE FUNCTION update_user_preferences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_user_preferences_timestamp
+BEFORE UPDATE ON user_preferences
+FOR EACH ROW
+EXECUTE PROCEDURE update_user_preferences_updated_at();
+
 -- RLS (Row Level Security) Reminder
 -- Ensure RLS is enabled on these tables in your Supabase dashboard
 -- and appropriate policies are created.

--- a/app/api/user-preferences/route.ts
+++ b/app/api/user-preferences/route.ts
@@ -1,0 +1,168 @@
+import { createClient } from "@/lib/supabase/server"
+import { NextRequest, NextResponse } from "next/server"
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+
+    if (!supabase) {
+      return NextResponse.json(
+        { error: "Database connection failed" },
+        { status: 500 }
+      )
+    }
+
+    // Get the current user
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    // Get the user's preferences
+    const { data, error } = await supabase
+      .from("user_preferences")
+      .select("*")
+      .eq("user_id", user.id)
+      .single()
+
+    if (error) {
+      // If no preferences exist, return defaults
+      if (error.code === "PGRST116") {
+        return NextResponse.json({
+          layout: "fullscreen",
+          prompt_suggestions: true,
+          show_tool_invocations: true,
+          show_conversation_previews: true,
+          multi_model_enabled: false,
+          hidden_models: [],
+        })
+      }
+
+      console.error("Error fetching user preferences:", error)
+      return NextResponse.json(
+        { error: "Failed to fetch user preferences" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      layout: data.layout,
+      prompt_suggestions: data.prompt_suggestions,
+      show_tool_invocations: data.show_tool_invocations,
+      show_conversation_previews: data.show_conversation_previews,
+      multi_model_enabled: data.multi_model_enabled,
+      hidden_models: data.hidden_models || [],
+    })
+  } catch (error) {
+    console.error("Error in user-preferences GET API:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+
+    if (!supabase) {
+      return NextResponse.json(
+        { error: "Database connection failed" },
+        { status: 500 }
+      )
+    }
+
+    // Get the current user
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    // Parse the request body
+    const body = await request.json()
+    const {
+      layout,
+      prompt_suggestions,
+      show_tool_invocations,
+      show_conversation_previews,
+      multi_model_enabled,
+      hidden_models,
+    } = body
+
+    // Validate the data types
+    if (layout && typeof layout !== "string") {
+      return NextResponse.json(
+        { error: "layout must be a string" },
+        { status: 400 }
+      )
+    }
+
+    if (hidden_models && !Array.isArray(hidden_models)) {
+      return NextResponse.json(
+        { error: "hidden_models must be an array" },
+        { status: 400 }
+      )
+    }
+
+    // Prepare update object with only provided fields
+    const updateData: any = {}
+    if (layout !== undefined) updateData.layout = layout
+    if (prompt_suggestions !== undefined)
+      updateData.prompt_suggestions = prompt_suggestions
+    if (show_tool_invocations !== undefined)
+      updateData.show_tool_invocations = show_tool_invocations
+    if (show_conversation_previews !== undefined)
+      updateData.show_conversation_previews = show_conversation_previews
+    if (multi_model_enabled !== undefined)
+      updateData.multi_model_enabled = multi_model_enabled
+    if (hidden_models !== undefined) updateData.hidden_models = hidden_models
+
+    // Try to update first, then insert if doesn't exist
+    const { data, error } = await supabase
+      .from("user_preferences")
+      .upsert(
+        {
+          user_id: user.id,
+          ...updateData,
+        },
+        {
+          onConflict: "user_id",
+        }
+      )
+      .select("*")
+      .single()
+
+    if (error) {
+      console.error("Error updating user preferences:", error)
+      return NextResponse.json(
+        { error: "Failed to update user preferences" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      layout: data.layout,
+      prompt_suggestions: data.prompt_suggestions,
+      show_tool_invocations: data.show_tool_invocations,
+      show_conversation_previews: data.show_conversation_previews,
+      multi_model_enabled: data.multi_model_enabled,
+      hidden_models: data.hidden_models || [],
+    })
+  } catch (error) {
+    console.error("Error in user-preferences PUT API:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,7 +57,10 @@ export default async function RootLayout({
             <ModelProvider>
               <ChatsProvider userId={userProfile?.id}>
                 <ChatSessionProvider>
-                  <UserPreferencesProvider userId={userProfile?.id}>
+                  <UserPreferencesProvider
+                    userId={userProfile?.id}
+                    initialPreferences={userProfile?.preferences}
+                  >
                     <TooltipProvider
                       delayDuration={200}
                       skipDelayDuration={500}

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -301,6 +301,50 @@ export type Database = {
           },
         ]
       }
+      user_preferences: {
+        Row: {
+          user_id: string
+          layout: string | null
+          prompt_suggestions: boolean | null
+          show_tool_invocations: boolean | null
+          show_conversation_previews: boolean | null
+          multi_model_enabled: boolean | null
+          hidden_models: string[] | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          user_id: string
+          layout?: string | null
+          prompt_suggestions?: boolean | null
+          show_tool_invocations?: boolean | null
+          show_conversation_previews?: boolean | null
+          multi_model_enabled?: boolean | null
+          hidden_models?: string[] | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          user_id?: string
+          layout?: string | null
+          prompt_suggestions?: boolean | null
+          show_tool_invocations?: boolean | null
+          show_conversation_previews?: boolean | null
+          multi_model_enabled?: boolean | null
+          hidden_models?: string[] | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_preferences_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       [_ in never]: never

--- a/app/types/user.ts
+++ b/app/types/user.ts
@@ -1,6 +1,0 @@
-import type { Tables } from "@/app/types/database.types"
-
-export type UserProfile = {
-  profile_image: string
-  display_name: string
-} & Tables<"users">

--- a/components/common/model-selector/base.tsx
+++ b/components/common/model-selector/base.tsx
@@ -162,7 +162,7 @@ export function ModelSelector({
     >
       <div className="flex items-center gap-2">
         {currentProvider?.icon && <currentProvider.icon className="size-5" />}
-        <span>{currentModel?.name || "Select model"}</span>
+        <span>{currentModel?.name}</span>
       </div>
       <CaretDownIcon className="size-4 opacity-50" />
     </Button>
@@ -172,6 +172,10 @@ export function ModelSelector({
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation()
     setSearchQuery(e.target.value)
+  }
+
+  if (isLoadingModels) {
+    return null
   }
 
   // If user is not authenticated, show the auth popover

--- a/lib/chat-store/chats/provider.tsx
+++ b/lib/chat-store/chats/provider.tsx
@@ -52,7 +52,7 @@ export function ChatsProvider({
   userId?: string
   children: React.ReactNode
 }) {
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [chats, setChats] = useState<Chats[]>([])
 
   useEffect(() => {

--- a/lib/model-store/provider.tsx
+++ b/lib/model-store/provider.tsx
@@ -47,7 +47,7 @@ export function ModelProvider({ children }: { children: React.ReactNode }) {
     anthropic: false,
   })
   const [favoriteModels, setFavoriteModels] = useState<string[]>([])
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   const fetchModels = useCallback(async () => {
     try {

--- a/lib/user-preference-store/provider.tsx
+++ b/lib/user-preference-store/provider.tsx
@@ -35,11 +35,94 @@ interface UserPreferencesContextType {
   setMultiModelEnabled: (enabled: boolean) => void
   toggleModelVisibility: (modelId: string) => void
   isModelHidden: (modelId: string) => boolean
+  isLoading: boolean
 }
 
 const UserPreferencesContext = createContext<
   UserPreferencesContextType | undefined
 >(undefined)
+
+// Helper functions to convert between API format (snake_case) and frontend format (camelCase)
+function convertFromApiFormat(apiData: any): UserPreferences {
+  return {
+    layout: apiData.layout || "fullscreen",
+    promptSuggestions: apiData.prompt_suggestions ?? true,
+    showToolInvocations: apiData.show_tool_invocations ?? true,
+    showConversationPreviews: apiData.show_conversation_previews ?? true,
+    multiModelEnabled: apiData.multi_model_enabled ?? false,
+    hiddenModels: apiData.hidden_models || [],
+  }
+}
+
+function convertToApiFormat(preferences: Partial<UserPreferences>) {
+  const apiData: any = {}
+  if (preferences.layout !== undefined) apiData.layout = preferences.layout
+  if (preferences.promptSuggestions !== undefined)
+    apiData.prompt_suggestions = preferences.promptSuggestions
+  if (preferences.showToolInvocations !== undefined)
+    apiData.show_tool_invocations = preferences.showToolInvocations
+  if (preferences.showConversationPreviews !== undefined)
+    apiData.show_conversation_previews = preferences.showConversationPreviews
+  if (preferences.multiModelEnabled !== undefined)
+    apiData.multi_model_enabled = preferences.multiModelEnabled
+  if (preferences.hiddenModels !== undefined)
+    apiData.hidden_models = preferences.hiddenModels
+  return apiData
+}
+
+async function fetchUserPreferences(): Promise<UserPreferences> {
+  const response = await fetch("/api/user-preferences")
+  if (!response.ok) {
+    throw new Error("Failed to fetch user preferences")
+  }
+  const data = await response.json()
+  return convertFromApiFormat(data)
+}
+
+async function updateUserPreferences(
+  update: Partial<UserPreferences>
+): Promise<UserPreferences> {
+  const response = await fetch("/api/user-preferences", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(convertToApiFormat(update)),
+  })
+
+  if (!response.ok) {
+    throw new Error("Failed to update user preferences")
+  }
+
+  const data = await response.json()
+  return convertFromApiFormat(data)
+}
+
+function getLocalStoragePreferences(): UserPreferences {
+  if (typeof window === "undefined") return defaultPreferences
+
+  const stored = localStorage.getItem(PREFERENCES_STORAGE_KEY)
+  if (stored) {
+    try {
+      return JSON.parse(stored)
+    } catch {
+      // fallback to legacy layout storage if JSON parsing fails
+    }
+  }
+
+  const layout = localStorage.getItem(LAYOUT_STORAGE_KEY) as LayoutType | null
+  return {
+    ...defaultPreferences,
+    ...(layout ? { layout } : {}),
+  }
+}
+
+function saveToLocalStorage(preferences: UserPreferences) {
+  if (typeof window === "undefined") return
+
+  localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(preferences))
+  localStorage.setItem(LAYOUT_STORAGE_KEY, preferences.layout)
+}
 
 export function UserPreferencesProvider({
   children,
@@ -51,41 +134,59 @@ export function UserPreferencesProvider({
   const isAuthenticated = !!userId
   const queryClient = useQueryClient()
 
-  const { data: preferences = defaultPreferences } = useQuery<UserPreferences>({
-    queryKey: ["user-preferences", userId],
-    queryFn: () => {
-      if (!isAuthenticated) {
-        return { ...defaultPreferences, layout: "fullscreen" }
-      }
+  // Query for user preferences
+  const { data: preferences = defaultPreferences, isLoading } =
+    useQuery<UserPreferences>({
+      queryKey: ["user-preferences", userId],
+      queryFn: async () => {
+        if (!isAuthenticated) {
+          return getLocalStoragePreferences()
+        }
 
-      const stored = localStorage.getItem(PREFERENCES_STORAGE_KEY)
-      if (stored) return JSON.parse(stored)
+        try {
+          return await fetchUserPreferences()
+        } catch (error) {
+          console.error(
+            "Failed to fetch user preferences, falling back to localStorage:",
+            error
+          )
+          return getLocalStoragePreferences()
+        }
+      },
+      enabled: typeof window !== "undefined",
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      retry: (failureCount, error) => {
+        // Only retry for authenticated users and network errors
+        return isAuthenticated && failureCount < 2
+      },
+    })
 
-      const layout = localStorage.getItem(
-        LAYOUT_STORAGE_KEY
-      ) as LayoutType | null
-      return {
-        ...defaultPreferences,
-        ...(layout ? { layout } : {}),
-      }
-    },
-    enabled: typeof window !== "undefined",
-    staleTime: Infinity,
-  })
-
+  // Mutation for updating preferences
   const mutation = useMutation({
     mutationFn: async (update: Partial<UserPreferences>) => {
       const updated = { ...preferences, ...update }
-      localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(updated))
-      localStorage.setItem(LAYOUT_STORAGE_KEY, updated.layout)
-      return updated
+
+      if (!isAuthenticated) {
+        saveToLocalStorage(updated)
+        return updated
+      }
+
+      try {
+        return await updateUserPreferences(update)
+      } catch (error) {
+        console.error(
+          "Failed to update user preferences in database, falling back to localStorage:",
+          error
+        )
+        saveToLocalStorage(updated)
+        return updated
+      }
     },
     onMutate: async (update) => {
       const queryKey = ["user-preferences", userId]
       await queryClient.cancelQueries({ queryKey })
 
       const previous = queryClient.getQueryData<UserPreferences>(queryKey)
-
       const optimistic = { ...previous, ...update }
       queryClient.setQueryData(queryKey, optimistic)
 
@@ -95,6 +196,9 @@ export function UserPreferencesProvider({
       if (context?.previous) {
         queryClient.setQueryData(["user-preferences", userId], context.previous)
       }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["user-preferences", userId], data)
     },
   })
 
@@ -147,6 +251,7 @@ export function UserPreferencesProvider({
         setMultiModelEnabled,
         toggleModelVisibility,
         isModelHidden,
+        isLoading,
       }}
     >
       {children}

--- a/lib/user-preference-store/provider.tsx
+++ b/lib/user-preference-store/provider.tsx
@@ -11,7 +11,7 @@ type UserPreferences = {
   showToolInvocations: boolean
   showConversationPreviews: boolean
   multiModelEnabled: boolean
-  hiddenModels: string[] // Array of model IDs that should be hidden
+  hiddenModels: string[]
 }
 
 const defaultPreferences: UserPreferences = {

--- a/lib/user-preference-store/utils.ts
+++ b/lib/user-preference-store/utils.ts
@@ -1,0 +1,47 @@
+export type LayoutType = "sidebar" | "fullscreen"
+
+export type UserPreferences = {
+  layout: LayoutType
+  promptSuggestions: boolean
+  showToolInvocations: boolean
+  showConversationPreviews: boolean
+  multiModelEnabled: boolean
+  hiddenModels: string[]
+}
+
+export const defaultPreferences: UserPreferences = {
+  layout: "fullscreen",
+  promptSuggestions: true,
+  showToolInvocations: true,
+  showConversationPreviews: true,
+  multiModelEnabled: false,
+  hiddenModels: [],
+}
+
+// Helper functions to convert between API format (snake_case) and frontend format (camelCase)
+export function convertFromApiFormat(apiData: any): UserPreferences {
+  return {
+    layout: apiData.layout || "fullscreen",
+    promptSuggestions: apiData.prompt_suggestions ?? true,
+    showToolInvocations: apiData.show_tool_invocations ?? true,
+    showConversationPreviews: apiData.show_conversation_previews ?? true,
+    multiModelEnabled: apiData.multi_model_enabled ?? false,
+    hiddenModels: apiData.hidden_models || [],
+  }
+}
+
+export function convertToApiFormat(preferences: Partial<UserPreferences>) {
+  const apiData: any = {}
+  if (preferences.layout !== undefined) apiData.layout = preferences.layout
+  if (preferences.promptSuggestions !== undefined)
+    apiData.prompt_suggestions = preferences.promptSuggestions
+  if (preferences.showToolInvocations !== undefined)
+    apiData.show_tool_invocations = preferences.showToolInvocations
+  if (preferences.showConversationPreviews !== undefined)
+    apiData.show_conversation_previews = preferences.showConversationPreviews
+  if (preferences.multiModelEnabled !== undefined)
+    apiData.multi_model_enabled = preferences.multiModelEnabled
+  if (preferences.hiddenModels !== undefined)
+    apiData.hidden_models = preferences.hiddenModels
+  return apiData
+}

--- a/lib/user/api.ts
+++ b/lib/user/api.ts
@@ -1,6 +1,12 @@
-import type { UserProfile } from "@/app/types/user"
+import type { Tables } from "@/app/types/database.types"
 import { isSupabaseEnabled } from "@/lib/supabase/config"
 import { createClient } from "@/lib/supabase/server"
+
+export type UserProfile = {
+  profile_image: string
+  display_name: string
+} & Tables<"users"> &
+  Tables<"user_preferences">
 
 export async function getSupabaseUser() {
   const supabase = await createClient()
@@ -30,7 +36,7 @@ export async function getUserProfile(): Promise<UserProfile | null> {
 
   const { data: userProfileData } = await supabase
     .from("users")
-    .select("*")
+    .select("*, user_preferences(*)")
     .eq("id", user.id)
     .single()
 


### PR DESCRIPTION
added user_preferences table with RLS

- fetched in getUserProfile() for SSR
- updated UserPreferencesProvider to accept initialPreferences
- added loading state to ChatsProvider
- model selector handles loading and fallback model safely
- fixes FOUC by loading preferences on the server