### PR TITLE
fix: Syntax error in messages schema

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,7 +209,8 @@ CREATE TABLE messages (
   role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'data')), -- Added CHECK constraint
   experimental_attachments JSONB, -- Storing Attachment[] as JSONB
   parts JSONB,
-  created_at TIMESTAMPTZ DEFAULT NOW(),  message_group_id TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  message_group_id TEXT,
   model TEXT,
   CONSTRAINT messages_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
   CONSTRAINT messages_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,11 +209,10 @@ CREATE TABLE messages (
   role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'data')), -- Added CHECK constraint
   experimental_attachments JSONB, -- Storing Attachment[] as JSONB
   parts JSONB,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),  message_group_id TEXT,
+  model TEXT,
   CONSTRAINT messages_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
   CONSTRAINT messages_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-  message_group_id TEXT,
-  model TEXT
 );
 
 -- Chat attachments table


### PR DESCRIPTION
## Problem
The current DB schema in [INSTALL.md](https://github.com/ibelick/zola.git) throws a syntax error when run in the Supabase SQL editor.

## Fix
Very simple. The fix was to move the `message_group_id TEXT` column before the table's constraint definitions.

<br />

<details>
<summary><b>Screenshot before fix: </b></summary>

<img width="1483" height="833" alt="Screenshot 2025-07-17 185928" src="https://github.com/user-attachments/assets/d6ad7c61-bf69-42a0-b60a-760314f537d8" />

</details>

<details>
<summary><b>Screenshot after fix: </b></summary>

<img width="1546" height="699" alt="image" src="https://github.com/user-attachments/assets/523c7784-8470-4727-af72-b544dd021fba" />


</details>