### PR TITLE
Fix: Clear chat preview after deleting a chat in history

### DIFF
--- a/app/components/history/command-history.tsx
+++ b/app/components/history/command-history.tsx
@@ -411,8 +411,15 @@ export function CommandHistory({
     async (id: string) => {
       setDeletingId(null)
       await onConfirmDelete(id)
+
+      // Clear preview and selection if the deleted chat was being previewed
+      if (hoveredChatId === id || selectedChatId === id) {
+        setHoveredChatId(null)
+        setSelectedChatId(null)
+        clearPreview()
+      }
     },
-    [onConfirmDelete]
+    [onConfirmDelete, hoveredChatId, selectedChatId, clearPreview]
   )
 
   const handleCancelDelete = useCallback(() => {


### PR DESCRIPTION
## Problem

Previously, the chat preview panel in command history would still show the deleted chat until another chat was hovered over. This PR fixes that bug.

### Steps to reproduce:
- Make sure **Conversation previews** is toggled on in the settings under **Appearance** tab
- Click `Ctrl+k` or `Cmd+k` to view chat history
- Hover over a conversation/chat item and delete it

<br />

<details>
<summary><b>Preview before fix: </b></summary>

https://github.com/user-attachments/assets/c26b5058-7368-4e98-9398-70c7bb60daad

</details>

<details>
<summary><b>Preview after fix: </b></summary>

https://github.com/user-attachments/assets/10c81d25-ec7f-44af-8dd1-34f0483a7613

</details>