### PR TITLE
Fix: Refresh models list upon adding api keys

### DIFF
--- a/app/components/layout/settings/apikeys/byok-section.tsx
+++ b/app/components/layout/settings/apikeys/byok-section.tsx
@@ -99,7 +99,7 @@ const PROVIDERS: Provider[] = [
 
 export function ByokSection() {
   const queryClient = useQueryClient()
-  const { userKeyStatus, refreshUserKeyStatus, refreshModels } = useModel()
+  const { userKeyStatus, refreshAll } = useModel()
   const [selectedProvider, setSelectedProvider] = useState<string>("openrouter")
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({})
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
@@ -146,8 +146,8 @@ export function ByokSection() {
           : `Your ${providerConfig?.name} API key has been updated.`,
       })
 
-      // Refresh models and user key status
-      await Promise.all([refreshUserKeyStatus(), refreshModels()])
+      // Use refreshAll to ensure models, user key status, and favorites are all in sync after saving a key
+      await refreshAll()
 
       // If new models were added to favorites, refresh the favorite models cache
       if (response.isNewKey) {
@@ -185,7 +185,7 @@ export function ByokSection() {
         title: "API key deleted",
         description: `Your ${providerConfig?.name} API key has been deleted.`,
       })
-      await Promise.all([refreshUserKeyStatus(), refreshModels()])
+      await refreshAll()
       setApiKeys((prev) => ({ ...prev, [provider]: "" }))
       setDeleteDialogOpen(false)
       setProviderToDelete("")


### PR DESCRIPTION
## Problem
- After saving a user API key, the model selector UI would show an empty/default state or stale data.

## Fix
- I removed the partial refresh calls and replaced them with a single  `refreshAll()` method in both save and delete mutations.
- Alternatively, manually calling `refreshModels()`, `refreshUserKeyStatus()`, and `refreshFavoriteModels()` in a promise.all works too.

<br />

<details>
<summary><b>Preview before fix: </b></summary>

https://github.com/user-attachments/assets/1443caf4-9bd9-4244-9759-fe5e0082598e

</details>

<details>
<summary><b>Preview after fix: </b></summary>

https://github.com/user-attachments/assets/781deaf5-f2ec-4a6b-91a7-2dabb7a2b8ad

</details>