### PR TITLE
Chore: Add key status indicator & responsive adjustments in mobile layout

### DIFF
--- a/app/components/layout/settings/apikeys/byok-section.tsx
+++ b/app/components/layout/settings/apikeys/byok-section.tsx
@@ -24,7 +24,7 @@ import { toast } from "@/components/ui/toast"
 import { fetchClient } from "@/lib/fetch"
 import { useModel } from "@/lib/model-store/provider"
 import { cn } from "@/lib/utils"
-import { PlusIcon } from "@phosphor-icons/react"
+import { KeyIcon, PlusIcon } from "@phosphor-icons/react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Loader2, Trash2 } from "lucide-react"
 import { useState } from "react"
@@ -232,19 +232,24 @@ export function ByokSection() {
         Your keys are stored securely with end-to-end encryption.
       </p>
 
-      <div className="mt-4 grid grid-cols-4 gap-3">
+      <div className="mt-4 grid grid-cols-2 gap-3 min-[400px]:grid-cols-3 min-[500px]:grid-cols-4">
         {PROVIDERS.map((provider) => (
           <button
             key={provider.id}
             type="button"
             onClick={() => setSelectedProvider(provider.id)}
             className={cn(
-              "flex aspect-square min-w-28 flex-col items-center justify-center gap-2 rounded-lg border p-4",
+              "relative flex aspect-square min-w-28 flex-col items-center justify-center gap-2 rounded-lg border p-4",
               selectedProvider === provider.id
                 ? "border-primary ring-primary/30 ring-2"
                 : "border-border"
             )}
           >
+            {userKeyStatus[provider.id] && (
+              <span className="absolute top-1 right-1 rounded-sm bg-green-200 p-1">
+                <KeyIcon className="size-3.5 text-green-800" />
+              </span>
+            )}
             <provider.icon className="size-4" />
             <span>{provider.name}</span>
           </button>


### PR DESCRIPTION
## Outline
Quick quality-of-life update: A key icon now appears on provider model tiles when a model has a saved key. 
This provides a quick visual cue. Let me know if you'd like me to change anything.

<details>
<summary><b>Screenshot of key status: </b></summary>

<img width="1919" height="1079" alt="Screenshot 2025-07-26 175121" src="https://github.com/user-attachments/assets/5e2c6cf5-5ae0-41d9-8b08-cd13edfda2d3" />

</details>

<br />

Also, improved the responsiveness of these tiles in mobile layout

<details>
<summary><b>Preview before changes: </b></summary>

https://github.com/user-attachments/assets/9fd21761-fa89-4402-a9fb-1ad405e0061e

</details>

<details>
<summary><b>Preview after changes: </b></summary>

https://github.com/user-attachments/assets/8dcf6ffe-7934-4ddf-b166-9871d2f1cbf4

</details>