### PR TITLE
Fix: quoted text style in dark mode

### DIFF
--- a/app/components/chat/message-user.tsx
+++ b/app/components/chat/message-user.tsx
@@ -155,7 +155,7 @@ export function MessageUser({
         </div>
       ) : (
         <MessageContent
-          className="bg-accent relative max-w-[70%] rounded-3xl px-5 py-2.5"
+          className="bg-accent prose dark:prose-invert relative max-w-[70%] rounded-3xl px-5 py-2.5"
           markdown={true}
           ref={contentRef}
           components={{


### PR DESCRIPTION
**Problem:** The quoted text in user messages had contrast issues in dark mode.

**Fix:** Added the classnames `prose dark:prose-invert` to `message-user.tsx`.

<br />

<details>
<summary><b>Preview before fix:</b></summary>

<img width="686" height="741" alt="Screenshot 2025-08-11 145122" src="https://github.com/user-attachments/assets/841cc75b-a530-4935-8f20-a670dbdad7de" />

</details>

<details>
<summary><b>Preview after fix:</b></summary>

<img width="699" height="747" alt="Screenshot 2025-08-11 145102" src="https://github.com/user-attachments/assets/50896ac9-0eeb-4cb4-8c12-b3e01970ddf2" />

</details>

**Resources:**
- [Stackoverflow thread](https://stackoverflow.com/questions/70954332/using-tailwind-prose-on-dark-background-makes-text-look-too-dark)